### PR TITLE
propogate error codes to the requester

### DIFF
--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -99,7 +99,15 @@ api.declare({
       // instead of a more complicated structure
 
       if (x === 0 && (result.status === 'absent' || result.status === 'error')) {
-        let validUrl = await validateUrl(url, this.allowedPatterns, this.redirectLimit, this.ensureSSL, this.monitor);
+        let validUrl;
+        try {
+          validUrl = await validateUrl(url, this.allowedPatterns, this.redirectLimit, this.ensureSSL, this.monitor);
+        } catch (err) {
+          return res.status(err.httpCode).json({
+            msg: 'upstream location returns error.  propogating',
+            upstreamHttpCode: err.httpCode,
+          });
+        }
 
         if (!validUrl) {
           return res.status(403).json({

--- a/src/validate-url.js
+++ b/src/validate-url.js
@@ -96,6 +96,7 @@ async function validateUrl (
       // Consider using an exponential backoff and retry here
       let err = new Error(`error reading input url.  ${sc}`);
       err.code = 'HTTPError';
+      err.httpCode = sc;
       if (monitor) {
         monitor.count('bad-input', 1);
         monitor.count(`bad-input.${sc}`, 1);

--- a/test-src/s3_integration_test.js
+++ b/test-src/s3_integration_test.js
@@ -194,12 +194,12 @@ describe('Integration Tests', () => {
 
   // For all error states which are unknown, make sure we return a 503 to
   // allow clients to retry
-  testFailure('should not cache a 400', httpbin + '/status/404', 500);
-  testFailure('should not cache a 401', httpbin + '/status/404', 500);
-  testFailure('should not cache a 403', httpbin + '/status/404', 500);
-  testFailure('should not cache a 404', httpbin + '/status/404', 500);
-  testFailure('should not cache a 500', httpbin + '/status/404', 500);
-  testFailure('should not cache a 503', httpbin + '/status/404', 500);
+  testFailure('should not cache a 400', httpbin + '/status/400', 400);
+  testFailure('should not cache a 401', httpbin + '/status/401', 401);
+  testFailure('should not cache a 403', httpbin + '/status/403', 403);
+  testFailure('should not cache a 404', httpbin + '/status/404', 404);
+  testFailure('should not cache a 500', httpbin + '/status/500', 500);
+  testFailure('should not cache a 503', httpbin + '/status/503', 503);
 
   // For cases where the request is not allowed, return 403
   testFailure('should only cache whitelisted url', 'https://www.facebook.com', 403);


### PR DESCRIPTION
basically, if we get an error code on the input url we set this as the status code of the request to /redirect