### PR TITLE
Monitor how long messages take to be processed

### DIFF
--- a/src/cache-manager.js
+++ b/src/cache-manager.js
@@ -284,6 +284,8 @@ class CacheManager {
       queue.send({
         id: this.id,
         url: rawUrl,
+        requested: new Date(),
+        action: 'putFile',
       });
     }));
     this.debug(`sent put request for ${rawUrl}`);


### PR DESCRIPTION
We should be monitoring how long it takes to go from a file being requested to being ready to work on.  This will tell us whether we should add more nodes or not
