### PR TITLE
Cloud Mirror Fixes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -88,11 +88,13 @@ production:
     trustProxy: true
 
 development:
+  backend:
+    count: 1
   sqsSimple:
     queueName: cloud-mirror-development
   app:
     ensureSSL: false
-    maxWaitForCachedCopy: 10000 #ms
+    maxWaitForCachedCopy: 100000 #ms
     allowedPatterns:
       - '^.*/'
   redis:

--- a/config.yml
+++ b/config.yml
@@ -111,6 +111,7 @@ test:
     maxWaitForCachedCopy: 5000 #ms
     allowedPatterns:
       - '^https://httpbin.org/'
+      - '^https://taskcluster-httpbin.herokuapp.com/'
       - '^https://www.google.com/'
       - '^https://google.com/'
       - '^http://www.google.com/'

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "slugid": "^1.1.0",
     "source-map-support": "^0.4.2",
     "sqs-simple": "^1.0.1",
-    "stream-meter": "^1.0.4",
     "superagent-promise": "^1.0.3",
     "taskcluster-lib-api": "^2.0.0",
     "taskcluster-lib-app": "^1.0.0",

--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -106,7 +106,11 @@ api.declare({
             ensureSSL: this.ensureSSL,
           });
         } catch (err) {
-          if (err.statusCode) {
+          if (err.code === 'InvalidUrl') {
+            return res.status(403).json({
+              msg: 'Invalid URL requested',
+            });
+          } else if (err.statusCode) {
             return res.status(err.statusCode).json({
               statusCode: err.statusCode,
               msg: err.message,

--- a/src/api-v1.js
+++ b/src/api-v1.js
@@ -106,20 +106,13 @@ api.declare({
             ensureSSL: this.ensureSSL,
           });
         } catch (err) {
-          if (err.code === 'InvalidUrl') {
-            return res.status(403).json({
-              msg: 'Invalid URL requested',
-            });
-          } else if (err.statusCode) {
+          if (err.code === 'BadHTTPStatus' || err.code === 'InvalidUrl') {
             return res.status(err.statusCode).json({
-              statusCode: err.statusCode,
               msg: err.message,
+              err: err.code,
             });
           } else {
-            debug('error while validating url: %s', err.stack || err);
-            return res.status(500).json({
-              msg: 'error while validating url',
-            });
+            throw err;
           }
         }
 
@@ -128,7 +121,6 @@ api.declare({
         // it not being there really is not an error case
         this.monitor.count(`${service}.${region}.cache-miss`, 1);
         this.monitor.count('cache-miss', 1);
-      } else {
       }
 
       if (result.status === 'present') {

--- a/src/cache-manager.js
+++ b/src/cache-manager.js
@@ -9,6 +9,7 @@ let requestPromise = require('request-promise').defaults({
 let request = require('request').defaults({
   followRedirect: false,
 });
+let request2 = require('./request').request;
 let fs = require('fs');
 let stream = require('stream');
 let debugModule = require('debug');
@@ -186,20 +187,19 @@ class CacheManager {
       throw new Error('URL is invalid: ' + rawUrl);
     }
 
-    let obj = request.get({
-      uri: urlInfo.url,
+    let response = await request2(urlInfo.url, {
       headers: {
         'Accept-Encoding': '*',
       },
     });
 
-    obj.on('error', err => {
+    response.on('error', err => {
       this.debug(`error reading input url stream ${err.stack || err}`);
       throw err;
     });
 
     return {
-      stream: obj,
+      stream: response,
       url: urlInfo.url,
       meta: urlInfo.meta,
       addresses: urlInfo.addresses,

--- a/src/cache-manager.js
+++ b/src/cache-manager.js
@@ -6,10 +6,7 @@ let requestPromise = require('request-promise').defaults({
   simple: false,
   resolveWithFullResponse: true,
 });
-let request = require('request').defaults({
-  followRedirect: false,
-});
-let request2 = require('./request').request;
+let request = require('./request').request;
 let fs = require('fs');
 let stream = require('stream');
 let debugModule = require('debug');
@@ -131,6 +128,7 @@ class CacheManager {
 
     if (!cacheEntry) {
       this.debug('cache entry not found for ' + rawUrl);
+
       let head = requestPromise.head({
         url: worldAddress,
         followRedirect: true,
@@ -187,7 +185,7 @@ class CacheManager {
       throw new Error('URL is invalid: ' + rawUrl);
     }
 
-    let response = await request2(urlInfo.url, {
+    let response = await request(urlInfo.url, {
       headers: {
         'Accept-Encoding': '*',
       },

--- a/src/main.js
+++ b/src/main.js
@@ -88,8 +88,7 @@ let load = base.loader({
       };
       //sqsCfg.logger = awsDebugLoggerBridge;
       let sqs = new aws.SQS(sqsCfg);
-      let m = monitor.prefix('sqs');
-      //m.patchAWS(sqs);
+      monitor.patchAWS(sqs);
       return sqs;
     },
   },
@@ -329,8 +328,7 @@ let load = base.loader({
 
         // Create the actual S3 object.
         let s3 = await s3Factory(region);
-        let m = monitor.prefix('s3');
-        //m.patchAWS(s3)
+        monitor.patchAWS(s3);
 
         let storageProvider = new S3StorageProvider({
           service: 's3',

--- a/src/main.js
+++ b/src/main.js
@@ -98,7 +98,7 @@ let load = base.loader({
     setup: ({process, profile, cfg}) => monitoring({
       project: 'cloud-mirror',
       credentials: cfg.taskcluster.credentials,
-      mock: profile === 'test',
+      mock: profile !== 'production',
       process,
     }),
   },

--- a/src/request.js
+++ b/src/request.js
@@ -1,0 +1,230 @@
+let http = require('http');
+let https = require('https');
+let assert = require('assert');
+let urllib = require('url');
+let debug = require('debug')('requests');
+
+let versionString = '/unknownversion';
+
+// Figure out the version string that we'll include in the user agent.  If we
+// cannot figure out the version string, we'll (in the future) figure out what
+// git/hg revision we're on and use that.
+try {
+  let pkgInfo = require('../package.json');
+  versionString = '/' + pkgInfo.version;
+} catch (err) { }
+
+let httpAgent = new http.Agent({
+  keepAlive: true,
+});
+
+let httpsAgent = new https.Agent({
+  keepAlive: true,
+});
+
+/**
+ * Return true if these headers are ones that we'll support and false if they
+ * aren't.  We only support headers where there is a single level deep mapping
+ * of string to string values
+ */
+function validateHeaders(headers) {
+  if (typeof headers !== 'object') {
+    return false;
+  }
+  for (let key of Object.keys(headers)) {
+    if (typeof headers[key] !== 'string') {
+      return false;
+    }
+  }
+  return true;
+}
+
+class RequestError extends Error {
+
+}
+
+/**
+ * Make a request against a URL.  The provided URL will be a correctly formed
+ * URL in a string.  This method will not follow any redirects.  This method
+ * will return a promise which resolves an object like {response, request}.
+ */
+async function request(url, opts = {}) {
+  assert(typeof url === 'string', 'must provide a url');
+  let urlParts = urllib.parse(url);
+  if (!opts.allowUnsafeUrls) {
+    debug('allowing unsafe urls');
+    assert(urlParts.protocol === 'https:', 'only https is supported');
+  }
+
+  let headers = opts.headers || {};
+  if (!validateHeaders(headers)) {
+    throw new RequestError('Headers are invalid');
+  }
+  headers['user-agent'] = 'cloud-mirror' + versionString;
+
+  let port;
+  try {
+    if (urlParts.port) {
+      port = parseInt(urlParts.port, 10);
+    }
+  } catch (err) {
+    throw new RequestError('Cannot parse port'); 
+  }
+
+  let method = opts.method || 'GET';
+  method = method.toUpperCase();
+
+  assert(http.METHODS.indexOf(method) !== -1);
+  
+  if (opts.stream) {
+    assert(typeof opts.contentType === 'string',
+        'when supplying a request body, you must specify content-type');
+    assert(!opts.data, 'if supplying a stream, you must not supply data');
+  }
+
+  if (opts.data) {
+    assert(typeof opts.contentType === 'string',
+        'when supplying a request body, you must specify content-type');
+    assert(!opts.stream, 'if supplying a stream, you must not supply data');
+  }
+
+  switch (urlParts.protocol) {
+    case 'https:':
+      return makeRequest({
+        httpLib: https,
+        hostname: urlParts.hostname,
+        port: port || 443,
+        path: urlParts.path || '/',
+        headers: headers,
+        method: method,
+        stream: opts.stream,
+        data: opts.data,
+        contentType: opts.contentType,
+        timeout: opts.timeout || 60000,
+      });
+      break;
+    case 'http:':
+      return makeRequest({
+        httpLib: http,
+        hostname: urlParts.hostname,
+        port: port || 80,
+        path: urlParts.path || '/',
+        headers: headers,
+        method: method,
+        stream: opts.stream,
+        data: opts.data,
+        contentType: opts.contentType,
+        timeout: opts.timeout || 60000,
+      });
+      break;
+    default:
+      throw new RequestError('Invalid protocol: ' + urlParts.protocol);
+      break;
+  }
+  
+}
+
+module.exports = {
+  request,
+  RequestError,
+};
+
+async function makeRequest(opts) {
+  assert(typeof opts === 'object');
+  assert(typeof opts.httpLib === 'object');
+  assert(typeof opts.hostname === 'string');
+  assert(typeof opts.port === 'number');
+  assert(typeof opts.path === 'string');
+  assert(typeof opts.method === 'string');
+  assert(typeof opts.headers === 'object');
+  assert(typeof opts.timeout === 'number');
+  if (opts.stream) {
+    assert(typeof opts.contentType === 'string');
+    assert(typeof opts.stream === 'object');
+    assert(typeof opts.stream.pipe === 'function');
+  }
+  if (opts.data) {
+    assert(typeof opts.contentType === 'string');
+    assert(typeof opts.data.length === 'number');
+  }
+
+  return new Promise(async (resolve, reject) => {
+    let request = opts.httpLib.request({
+      hostname: opts.hostname,
+      port: opts.port,
+      path: opts.path,
+      method: opts.method,
+    });
+
+    // We don't want connections hanging around forever, so we'll set a fatal
+    // condition that they timeout if they aren't responded to quickly enough
+    request.setTimeout(opts.timeout);
+
+    // Set all headers which are specified in the request
+    for (let key of Object.keys(opts.headers)) {
+      request.setHeader(key, opts.headers[key]);
+      debug(`set header ${key} to value ${opts.headers[key]}`);
+    }
+
+    // If we have an input stream for the request, we should specify
+    // that here.  
+    if (opts.stream) {
+      request.setHeader('content-type', opts.contentType);
+      debug('piping input stream to request');
+      opts.stream.pipe(request);
+
+      opts.stream.on('end', () => {
+        debug('input stream completed, ending request');
+        request.end();
+      });
+
+      opts.stream.on('error', err => {
+        debug('error on input stream, aborting request');
+        request.abort();
+      });
+    } else if (opts.data) {
+      request.setHeader('content-type', opts.contentType);
+      request.setHeader('content-length', opts.data.length);
+      debug('writing: ' + opts.data);
+      request.write(opts.data);
+      request.end();
+    } else {
+      request.end();
+    }
+
+    request.on('socket', socket => {
+      debug('have a socket');
+
+      socket.on('error', err => {
+        debug('socket error');
+        reject(err);
+      });
+
+      socket.on('close', had_error => {
+        reject(new RequestError('Socket closed with error'));
+      });
+
+    });
+
+    request.on('response', response => {
+      response.socket.on('error', err => {
+        debug('response socket error: ' + err.stack || err);
+      });
+      resolve(response);
+    });
+
+    request.on('abort', () => {
+      reject(new RequestError('Request aborted by client (us)'));
+    });
+
+    request.on('aborted', () => {
+      reject(new RequestError('Request aborted by server (them)'));
+    });
+
+    request.on('timeout', () => {
+      request.abort();
+      reject(new RequestError('Request timeout occured'));
+    });
+  });
+}
+

--- a/src/s3-storage-provider.js
+++ b/src/s3-storage-provider.js
@@ -146,7 +146,7 @@ class S3StorageProvider extends StorageProvider {
   async expirationDate(response) {
     let header = response.headers['x-amz-expiration'];
     if (!header) {
-      throw new Error(JSON.stringify(response.headers, null, 2));
+      throw new Error('Missing x-amz-expiration');
     }
     // This header is sent in such a silly format.  Using cookie format or
     // sending the value without packing it in with a second value (rule-id)

--- a/src/s3-storage-provider.js
+++ b/src/s3-storage-provider.js
@@ -76,15 +76,6 @@ class S3StorageProvider extends StorageProvider {
   }
 
   /**
-   * Ensure that our bucket exists
-   */
-  async init() {
-    this.debug(`creating ${this.bucket}`);
-    await createS3Bucket(this.s3, this.bucket, this.region, this.acl, this.lifespan);
-    this.debug(`creating ${this.bucket}`);
-  }
-
-  /**
    * StorageProvider.put() implementation for S3
    */
   async put(rawUrl, inputStream, headers, storageMetadata) {

--- a/src/storage-provider.js
+++ b/src/storage-provider.js
@@ -33,12 +33,6 @@ class StorageProvider {
   }
 
   /**
-   * Perform any async init code require for this storage provider.  Default action
-   * is for there to be no init code.
-   */
-  async init() { }
-
-  /**
    * Store a file with the StorageProvider.  This must be overridden with a method
    * which takes:
    *   - rawUrl: the original input url as plain text

--- a/src/storage-provider.js
+++ b/src/storage-provider.js
@@ -43,7 +43,7 @@ class StorageProvider {
    *
    * and inserts the object into the storage provider
    */
-  async put(rawUrl, inputStream, headers, storageMetadata) {
+  async put(rawUrl, inputStream, headers, storageMetadata, rawInputStream) {
     throw new Error('This StorageProvider implementation must implement .put()');
   }
 

--- a/src/validate-url.js
+++ b/src/validate-url.js
@@ -49,6 +49,7 @@ async function followRedirect(opts) {
       err.url = u;
       err.addresses = addresses;
       err.code = 'InvalidUrl';
+      err.statusCode = 403;
       throw err;
     }
 
@@ -89,11 +90,12 @@ async function followRedirect(opts) {
         err.urlFrom = u;
         err.urlTo = locHead;
         err.code = 'RedirectMissingLocationHeader';
+        err.statusCode = 500;
         throw err;
       }
       u = url.resolve(u, locHead);
     } else {
-      debug('found bad status code');
+      debug('found bad status code: ' + code);
       let err = new Error('Unexpected HTTP Status: ' + code);
       err.statusCode = code;
       err.headers = result.headers;

--- a/src/validate-url.js
+++ b/src/validate-url.js
@@ -1,8 +1,4 @@
-let request = require('request-promise').defaults({
-  followRedirect: false,
-  simple: false,
-  resolveWithFullResponse: true,
-});
+let request = require('./request').request;
 let debug = require('debug')('cloud-mirror:follow-redirects');
 let assert = require('assert');
 let url = require('url');
@@ -64,8 +60,9 @@ async function validateUrl(
       return false;
     }
 
-    let result = await request.head(u);
+    let result = await request(u, {method: 'HEAD'});
     let sc = result.statusCode;
+    assert(sc);
 
     // We store the chain of URLs that make up this redirection.  This could be
     // used if we wished to provide an audit trail in consuming systems

--- a/src/validate-url.js
+++ b/src/validate-url.js
@@ -48,6 +48,7 @@ async function followRedirect(opts) {
       let err = new Error('URL does not validate: ' + u);
       err.url = u;
       err.addresses = addresses;
+      err.code = 'InvalidUrl';
       throw err;
     }
 
@@ -62,6 +63,7 @@ async function followRedirect(opts) {
       err.statusCode = code;
       err.addresses = addresses;
       err.url = u;
+      err.code = 'UnexpectedStatus';
       throw err;
     }
   
@@ -86,6 +88,7 @@ async function followRedirect(opts) {
         let err = new Error('Redirect missing location header');
         err.urlFrom = u;
         err.urlTo = locHead;
+        err.code = 'RedirectMissingLocationHeader';
         throw err;
       }
       u = url.resolve(u, locHead);
@@ -94,6 +97,7 @@ async function followRedirect(opts) {
       let err = new Error('Unexpected HTTP Status: ' + code);
       err.statusCode = code;
       err.headers = result.headers;
+      err.code = 'BadHTTPStatus';
       throw err;
     }
   }

--- a/test-src/request_test.js
+++ b/test-src/request_test.js
@@ -18,6 +18,13 @@ describe('request', () => {
     // just need to change this field.
     assume(response.headers.server).is.OK;
   });
+
+  for (let code of [200, 302, 404, 500]) {
+    it('should handle a ' + code, async () => {
+      let response = await subject.request(httpsBin + '/status/' + code);
+      assume(response.statusCode).equals(code);
+    });
+  }
   
   it('should complete an HTTPS GET request', async () => {
     let response = await subject.request(httpsBin + '/user-agent');
@@ -87,5 +94,28 @@ describe('request', () => {
         rej(err);
       }
     });
+  });
+
+  describe('bad certs', () => {
+    let badCerts = {
+      expired: 'https://expired.badssl.com/',
+      'wrong-host': 'https://wrong.host.badssl.com/',
+      'self-signed': 'https://self-signed.badssl.com/',
+      'untrusted-root': 'https://untrusted-root.badssl.com/',
+      // 'revoked': 'https://revoked.badssl.com/',
+    };
+
+    for (let type of Object.keys(badCerts)) {
+      it('should fail on ' + type + ' cert', async () => {
+        try {
+          await subject.request(badCerts[type]);
+          return Promise.reject(new Error('should have thrown'));
+        } catch (err) {
+          return Promise.resolve();
+        }
+      });
+
+    }
+
   });
 });

--- a/test-src/request_test.js
+++ b/test-src/request_test.js
@@ -1,0 +1,91 @@
+let assume = require('assume');
+let subject = require('../lib/request');
+let fs = require('fs');
+let memstream = require('memory-streams');
+
+let httpBin = 'http://taskcluster-httpbin.herokuapp.com';
+let httpsBin = 'https://taskcluster-httpbin.herokuapp.com';
+// Sometimes, It's useful to run nc -l 1080 on your machine and see *exactly*
+// what is being sent
+//httpBin = 'http://localhost:1080';
+
+describe('request', () => {
+  it('should complete an HTTP GET request', async () => {
+    let response = await subject.request(httpBin + '/user-agent', {
+      allowUnsafeUrls: true,
+    });
+    // Heh, this will likely change if they change their server, but then we'll
+    // just need to change this field.
+    assume(response.headers.server).is.OK;
+  });
+  
+  it('should complete an HTTPS GET request', async () => {
+    let response = await subject.request(httpsBin + '/user-agent');
+    // Heh, this will likely change if they change their server, but then we'll
+    // just need to change this field.
+    assume(response.headers.server).is.OK;
+  });
+
+  it('should complete a streamed POST request', async () => {
+    return new Promise(async (res, rej) => {
+      try {
+        let reader = fs.createReadStream(require.resolve('../package.json'));
+        let writer = new memstream.WritableStream();
+
+        reader.on('error', rej);
+        writer.on('error', rej);
+
+        let response = await subject.request(httpBin + '/post', {
+          method: 'post',
+          stream: reader,
+          contentType: 'application/json',
+          allowUnsafeUrls: true,
+        });
+
+        assume(response.headers.server).is.OK;
+
+        response.pipe(writer);
+
+        response.on('end', () => {
+          // NOTE: There is a bug in httpbin 
+          // https://github.com/Runscope/httpbin/issues/102
+          // that causes streamed responses not to work properly
+          // which means that we don't get an echo-back of data
+          res();
+        });
+      } catch (err) {
+        rej(err);
+      }
+    });
+  });
+
+  it('should complete a non-streamed POST request', async () => {
+    return new Promise(async (res, rej) => {
+      try {
+        //let data = fs.readFileSync(require.resolve('../package.json'));
+        let writer = new memstream.WritableStream();
+
+        writer.on('error', rej);
+
+        let response = await subject.request(httpBin + '/post', {
+          method: 'post',
+          data: new Buffer('john!'),
+          contentType: 'application/json',
+          allowUnsafeUrls: true,
+        });
+
+        assume(response.headers.server).is.OK;
+
+        response.pipe(writer);
+
+        response.on('end', () => {
+          let data = JSON.parse(writer.toBuffer());
+          assume(data.data).equals('john!');
+          res();
+        });
+      } catch (err) {
+        rej(err);
+      }
+    });
+  });
+});

--- a/test-src/s3_integration_test.js
+++ b/test-src/s3_integration_test.js
@@ -158,6 +158,7 @@ describe('Integration Tests', () => {
       let expected = await request(testUrl, {
         headers: {
           'Accept-Encoding': '*',
+          'User-Agent': 'cloud-mirror/1.0.0',
         },
       });
       let actual1 = await request(expectedRedirect);

--- a/test-src/s3_integration_test.js
+++ b/test-src/s3_integration_test.js
@@ -119,7 +119,7 @@ describe('Integration Tests', () => {
   });
 
   after(async () => {
-    await emptyBucket(cfg.aws, cacheManager.storageProvider.bucket);
+    //await emptyBucket(cfg.aws, cacheManager.storageProvider.bucket);
   });
 
   function assertRedirected(expected, actual) {

--- a/test-src/validate_url_test.js
+++ b/test-src/validate_url_test.js
@@ -3,30 +3,48 @@ let assume = require('assume');
 
 describe('url following and validation', () => {
   it('should follow Urls and validate them', async () => {
-    let result = await subject('https://taskcluster-httpbin.herokuapp.com/redirect/6');
+    let result = await subject({
+      url: 'https://taskcluster-httpbin.herokuapp.com/redirect/6',
+      allowedPatterns: [/.*/],
+      ensureSSL: true,
+    });
     console.dir(result);
     assume(result.addresses.length).equals(7);
   });
 
+  // TODO: make sure that the caught errors have a message that's expected
+
   it('should complain about too many redirects', async () => {
-    let result = await subject('https://taskcluster-httpbin.herokuapp.com/redirect/32');
-    if (result !== false) {
-      throw new Error();
-    }
+    try {
+      let result = await subject({
+        url: 'https://taskcluster-httpbin.herokuapp.com/redirect/100',
+        allowedPatterns: [/.*/],
+        ensureSSL: true,
+      });
+      return Promse.reject(new Error());
+    } catch (err) { }
   });
 
   it('should complain about insecure urls', async () => {
-    let result = await subject('http://taskcluster-httpbin.herokuapp.com/redirect/32');
-    if (result !== false) {
-      throw new Error();
-    }
+    try {
+      let result = await subject({
+        url: 'http://taskcluster-httpbin.herokuapp.com/redirect/2',
+        allowedPatterns: [/.*/],
+        ensureSSL: true,
+      });
+      return Promse.reject(new Error());
+    } catch (err) { }
   });
 
   it('should complain about non-matching urls', async () => {
-    let result = await subject('http://taskcluster-httpbin.herokuapp.com/redirect/32', [/john/]);
-    if (result !== false) {
-      throw new Error();
-    }
+    try {
+      let result = await subject({
+        url: 'http://taskcluster-httpbin.herokuapp.com/redirect/2',
+        allowedPatterns: [/^noturl$/],
+        ensureSSL: true,
+      });
+      return Promse.reject(new Error());
+    } catch (err) { }
   });
 
 });

--- a/test-src/validate_url_test.js
+++ b/test-src/validate_url_test.js
@@ -1,0 +1,32 @@
+let subject = require('../lib/validate-url');
+let assume = require('assume');
+
+describe('url following and validation', () => {
+  it('should follow Urls and validate them', async () => {
+    let result = await subject('https://taskcluster-httpbin.herokuapp.com/redirect/6');
+    console.dir(result);
+    assume(result.addresses.length).equals(7);
+  });
+
+  it('should complain about too many redirects', async () => {
+    let result = await subject('https://taskcluster-httpbin.herokuapp.com/redirect/32');
+    if (result !== false) {
+      throw new Error();
+    }
+  });
+
+  it('should complain about insecure urls', async () => {
+    let result = await subject('http://taskcluster-httpbin.herokuapp.com/redirect/32');
+    if (result !== false) {
+      throw new Error();
+    }
+  });
+
+  it('should complain about non-matching urls', async () => {
+    let result = await subject('http://taskcluster-httpbin.herokuapp.com/redirect/32', [/john/]);
+    if (result !== false) {
+      throw new Error();
+    }
+  });
+
+});


### PR DESCRIPTION
This seems to work really well.  The key things here are:
1. rewrite of the input stream code.  Now using the http/https node stdlib modules rather than request.  I still use request for unit tests (i think) because it's easier
2. changed how the streams are passed around so that we can listen for the `abort` event in the `wrapSend()` method to trigger a multipart upload abort when we have a stream abort.  I suspect this is the underlying cause.  Too bad that the error message doesn't also handle aborts...
3. a bunch of fixes around making unit tests not suck to run.  You'll have to initiate the SQS queue and S3 buckets manually, but that saves many many seconds when running unit tests.

@jonasfj and @imbstack do you think you guys could take a look at this before I merge it?  Please pay special attention to the request.js file, and also see if you can think of any events that I haven't handled properly.

TODO:
1. put a `lib-monitor` instance in `wrapSend()` to have metrics of input failures.
