### PR TITLE
bug 1318648 - support instance instantiation in us-east-2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -31,7 +31,7 @@ defaults:
   backend:
     count: 100
     s3:
-      regions: 'us-west-1,us-east-1,eu-central-1'
+      regions: 'us-west-1,us-east-1,us-east-2,eu-central-1'
       acl: 'public-read'
       bucketBase: 'cloud-mirror-' # bucketName = bucketBase + profile + '-' + region
       lifespan: 1 # in days, how long should S3 keep this


### PR DESCRIPTION
in anticipation of increased load for g2.2xlarge (gecko-t-win7-32-gpu, gecko-t-win10-64-gpu worker types) enable instance instantiation in us-east-2 to mitigate cost and availability issues